### PR TITLE
Add note about using `-l-au` to reduce eventlog size

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -31,14 +31,16 @@ Then, run your program with the normal profiling flags with an additional `-l`
 flag. This will tell GHC to also emit the eventlog.
 
 ```
-my-leaky-program +RTS -hy -l
+my-leaky-program +RTS -hy -l-au
 ```
 
 In the current directory a file `my-leaky-program.eventlog` will be produced.
 This is what you need to pass to `eventlog2html` to generate the profiling
 graphs.
 
-
+Note: The `-l-au` suffix will result in a significantly smaller eventlog
+as it will not include thread events. This makes a big difference for
+multi-threaded applications.
 
 ### Adding markers
 

--- a/eventlog2html.cabal
+++ b/eventlog2html.cabal
@@ -25,7 +25,7 @@ Extra-source-files:
   javascript/vega-embed@4.2.0
   javascript/vega@5.4.0
   javascript/stylesheet.css
-  javascript/tablogic.js                                    
+  javascript/tablogic.js
 Cabal-version:       >=1.8
 Tested-With:         GHC ==8.6.4
 


### PR DESCRIPTION
This makes eventlogs much, much smaller.