### PR TITLE
Formatting tweaks

### DIFF
--- a/docs/templates/examples.html
+++ b/docs/templates/examples.html
@@ -2,7 +2,7 @@
     <div class="row justify-content-center">
 $for(examples)$
       <div class="col-auto mb-3">
-      <div class="card" style="width: $width$px;">
+      <div class="card text-center" style="width: $width$px;">
         <div class="card-body">$body$
         <a href="$url$">$title$</a>
         </div>

--- a/hakyll-eventlog/site.hs
+++ b/hakyll-eventlog/site.hs
@@ -54,7 +54,7 @@ main = do
         compile $ do
             examples <- loadAllSnapshots "examples/*" "snippet"
             let widthCtx =
-                    constField "width" (show $ cwidth exampleConf) `mappend`
+                    constField "width" (show $ (cwidth exampleConf + 50)) `mappend`
                     defaultContext
             let examplesCtx =
                     listField "examples" widthCtx (return examples) `mappend`

--- a/hakyll-eventlog/site.hs
+++ b/hakyll-eventlog/site.hs
@@ -92,11 +92,13 @@ renderEventlog p = do
 insertEventlogs :: IORef Int -> Block -> IO Block
 insertEventlogs c block@(CodeBlock (ident, classes, attrs) code) | "eventlog" `elem` classes = do
    d <- eventlogSnippet c (words code) (chartConfig attrs)
-   return (RawBlock (Format "html") d)
+   return $ wrap (RawBlock (Format "html") d)
 insertEventlogs _ (CodeBlock (_, ["help"], _) _) = insertHelp
 insertEventlogs _ (c@(CodeBlock {})) = return $ Div ("", ["bg-light"],[]) [c]
 insertEventlogs _ block = return block
 
+wrap :: Block -> Block
+wrap b = Div ("", ["card", "mx-auto"],[("style", "max-width: 600px")]) [Div ("", ["card-body"],[]) [b]]
 
 render c = Div ("", ["bg-light"], []) [CodeBlock nullAttr ("> eventlog2html " ++ c)]
 

--- a/src/VegaTemplate.hs
+++ b/src/VegaTemplate.hs
@@ -61,15 +61,18 @@ vegaJsonText :: ChartConfig -> Text
 vegaJsonText conf = toStrict (encodeToLazyText (vegaJson conf))
 
 vegaResult :: ChartConfig -> VegaLite
-vegaResult conf = toVegaLite
+vegaResult conf = toVegaLite $
+  -- Subtract 100 from the width for the fixed size label allocation.
+  let c' = conf { cwidth = cwidth conf - 130 }
+  in
   [
     VL.width (cwidth conf),
     VL.height (cheight conf),
     config [],
     description "Heap Profile",
     case chartType conf of
-      LineChart -> lineChartFull conf
-      AreaChart ct -> areaChartFull ct conf
+      LineChart -> lineChartFull c'
+      AreaChart ct -> areaChartFull ct c'
   ]
 
 areaChartFull :: AreaChartType -> ChartConfig -> (VLProperty, VLSpec)
@@ -101,7 +104,7 @@ lineChart c = asSpec [layer ([linesLayer c] ++ [tracesLayer | traces c])]
 linesLayer :: ChartConfig -> VLSpec
 linesLayer c = asSpec
   [
-    VL.width (0.75 * cwidth c),
+    VL.width (0.9 * cwidth c),
     VL.height (0.7 * cheight c),
     dataFromSource "data_json_samples" [],
     VL.mark Line [],
@@ -153,7 +156,7 @@ brush = (selection . injectJSON "brush" (object [ "type" .= String "interval"
 
 selectionChart :: ChartConfig -> VLSpec
 selectionChart c = asSpec [
-    VL.width (0.75 * cwidth c),
+    VL.width (0.9 * cwidth c),
     VL.height (0.1 * cheight c),
     dataFromSource "data_json_samples" [],
     VL.mark Area [],
@@ -177,7 +180,7 @@ areaChart ct c = asSpec [layer ([bandsLayer ct c] ++ [tracesLayer | traces c])]
 bandsLayer :: AreaChartType -> ChartConfig -> VLSpec
 bandsLayer ct c = asSpec
   [
-    VL.width (0.75 * cwidth c),
+    VL.width (0.9 * cwidth c),
     VL.height (0.7 * cheight c),
     dataFromSource "data_json_samples" [],
     VL.mark Area [],
@@ -198,7 +201,10 @@ encodingBandsLayer ct c =
     . position Y [PName "y"
                  , PmType Quantitative
                  , PAxis $ case ct of
-                             Stacked -> [AxTitle "Allocation", AxFormat "s", AxMaxExtent 20.0, AxLabelOverlap OGreedy]
+                             Stacked -> [AxTitle "Allocation"
+                                        , AxFormat "s"
+                                        , AxTitlePadding 15.0
+                                        , AxMaxExtent 15.0]
                              Normalized -> [AxTitle "Allocation (Normalized)", AxFormat "p"]
                              StreamGraph -> [AxTitle "Allocation (Streamgraph)", AxLabels False, AxTicks False, AxTitlePadding 10.0]
                  , PAggregate Sum
@@ -271,7 +277,12 @@ encodingRight =
                     ])
   . position Y [PName "c"
                , PmType Nominal
-               , PAxis [AxOrient SRight, AxDomain False, AxTicks False, AxGrid False]
+               , PAxis [ AxOrient SRight
+                       , AxDomain False
+                       , AxTicks False
+                       , AxGrid False
+                       , AxMinExtent 100
+                       , AxMaxExtent 100]
                , PSort [(ByField "k"), Descending]]
 
 selectionRight :: [LabelledSpec] -> (VLProperty, VLSpec)


### PR DESCRIPTION
I'm not very happy with this patch. It involves lots of magical numbers but seeing as `vega-lite` is not very good at auto resizing I can't see another way. The end result looks decent enough I think?

Before:

![image](https://user-images.githubusercontent.com/1216657/59969450-e7283f00-9544-11e9-897b-4298a278f735.png)
![image](https://user-images.githubusercontent.com/1216657/59969455-f0191080-9544-11e9-87eb-9ab835ddae8c.png)
![image](https://user-images.githubusercontent.com/1216657/59969458-fdce9600-9544-11e9-8ff1-98b9c4d5e7ec.png)

After:

![image](https://user-images.githubusercontent.com/1216657/59969464-1c349180-9545-11e9-88f4-bdfdadae3f37.png)
![image](https://user-images.githubusercontent.com/1216657/59969467-2a82ad80-9545-11e9-9f93-c2226a5790bb.png)
![image](https://user-images.githubusercontent.com/1216657/59969470-3e2e1400-9545-11e9-8c6a-595e258821af.png)

