### PR TITLE
Refactor backend

### DIFF
--- a/main/Main.hs
+++ b/main/Main.hs
@@ -8,15 +8,9 @@ import Data.Aeson (encodeFile, Value, toJSON)
 import System.FilePath
 import System.Exit
 
-import Args (args, Args(..), Sort(..))
-import Bands (bands)
-import qualified Events as E
-import qualified HeapProf as H
+import Args (args, Args(..))
 import HtmlTemplate
-import Prune (prune, cmpName, cmpSize, cmpStdDev)
-import Total (total)
 import Data
-import Vega
 import VegaTemplate
 
 main :: IO ()

--- a/src/Data.hs
+++ b/src/Data.hs
@@ -10,7 +10,7 @@ import Args (Args(..), Sort(..))
 import Bands (bands)
 import qualified Events as E
 import qualified HeapProf as H
-import Prune (prune, Compare, cmpName, cmpSize, cmpStdDev)
+import Prune (prune, Compare, cmpNameAscending, cmpSizeAscending, cmpStdDevAscending)
 import Total (total)
 import Vega
 import Types (Header)
@@ -21,10 +21,10 @@ selectComparison :: Args -> Compare (Text, (Double, Double))
 selectComparison a =
   let
     sorting' = case sorting a of
-                 Name -> cmpName
-                 Size -> cmpSize
-                 StdDev -> cmpStdDev
-  in if reversing a then snd sorting' else fst sorting'
+                 Name -> cmpNameAscending
+                 Size -> cmpSizeAscending
+                 StdDev -> cmpStdDevAscending
+  in if reversing a then flip sorting' else sorting'
 
 generateJson :: FilePath -> Args -> IO (Header, Value)
 generateJson file a = do

--- a/src/Data.hs
+++ b/src/Data.hs
@@ -30,8 +30,8 @@ generateJson :: FilePath -> Args -> IO (Header, Value)
 generateJson file a = do
   let chunk = if heapProfile a then H.chunk else E.chunk
       cmp = selectComparison a
-  (ph, fs, traces) <- chunk file
-  let (h, totals) = total ph fs
+  (h, fs, traces) <- chunk file
+  let totals = total fs
   let keeps = prune cmp 0 (bound $ nBands a) totals
   let combinedJson = object [
           "samples" .= bandsToVega keeps (bands h keeps fs)

--- a/src/Data.hs
+++ b/src/Data.hs
@@ -4,25 +4,32 @@ module Data (generateJson) where
 import Prelude hiding (print, readFile)
 import Data.Aeson (Value(..), toJSON, (.=), object)
 import Data.Tuple (swap)
+import Data.Text (Text)
 
 import Args (Args(..), Sort(..))
 import Bands (bands)
 import qualified Events as E
 import qualified HeapProf as H
-import Prune (prune, cmpName, cmpSize, cmpStdDev)
+import Prune (prune, Compare, cmpName, cmpSize, cmpStdDev)
 import Total (total)
 import Vega
 import Types (Header)
 
+-- | Select the correct comparison function from the arguments
+-- specified at the command line.
+selectComparison :: Args -> Compare (Text, (Double, Double))
+selectComparison a =
+  let
+    sorting' = case sorting a of
+                 Name -> cmpName
+                 Size -> cmpSize
+                 StdDev -> cmpStdDev
+  in if reversing a then snd sorting' else fst sorting'
+
 generateJson :: FilePath -> Args -> IO (Header, Value)
 generateJson file a = do
   let chunk = if heapProfile a then H.chunk else E.chunk
-      cmp = fst $ reversing' sorting'
-      sorting' = case sorting a of
-        Name -> cmpName
-        Size -> cmpSize
-        StdDev -> cmpStdDev
-      reversing' = if reversing a then swap else id
+      cmp = selectComparison a
   (ph, fs, traces) <- chunk file
   let (h, totals) = total ph fs
   let keeps = prune cmp 0 (bound $ nBands a) totals

--- a/src/Events.hs
+++ b/src/Events.hs
@@ -102,6 +102,7 @@ elHeader EL{..} =
    --   dl = formatTime defaultTimeLocale "%c"
    --      . posixSecondsToUTCTime $ realToFrac start
 
-  in Header title "aaa" "" "" (length frames)
+ in Header title "aaa" "" "" (length frames + 2)
+ -- The 2 Corresponds to the additional 2 frames inserted in eventsToHP
 
 

--- a/src/Events.hs
+++ b/src/Events.hs
@@ -19,14 +19,14 @@ import Data.Word
 fromNano :: Word64 -> Double
 fromNano e = fromIntegral e * 1e-9
 
-chunk :: FilePath -> IO (PartialHeader, [Frame], [Trace])
+chunk :: FilePath -> IO (Header, [Frame], [Trace])
 chunk f = eventlogToHP . either error id =<< readEventLogFromFile f
 
-eventlogToHP :: EventLog -> IO (PartialHeader, [Frame], [Trace])
+eventlogToHP :: EventLog -> IO (Header, [Frame], [Trace])
 eventlogToHP (EventLog _h e) = do
   eventsToHP e
 
-eventsToHP :: Data -> IO (PartialHeader, [Frame], [Trace])
+eventsToHP :: Data -> IO (Header, [Frame], [Trace])
 eventsToHP (Data es) = do
   let
       el@EL{..} = foldEvents es
@@ -96,12 +96,12 @@ updateLast :: Word64 -> EL -> EL
 updateLast t el = el { end = t }
 
 
-elHeader :: EL -> PartialHeader
+elHeader :: EL -> Header
 elHeader EL{..} =
   let title = maybe "" (T.unwords . map T.pack) pargs
    --   dl = formatTime defaultTimeLocale "%c"
    --      . posixSecondsToUTCTime $ realToFrac start
 
-  in Header title "aaa" "" ""
+  in Header title "aaa" "" "" (length frames)
 
 

--- a/src/HeapProf.hs
+++ b/src/HeapProf.hs
@@ -8,13 +8,17 @@ import Data.Attoparsec.Text (parseOnly, double)
 
 import Types
 
-chunk :: FilePath -> IO (PartialHeader, [Frame], [Trace])
+myLength :: [a] -> Int
+myLength [] = 0
+myLength (_:xs) = 1 + myLength xs
+
+chunk :: FilePath -> IO (Header, [Frame], [Trace])
 chunk f = do
   (ph, fs) <- chunkT <$> readFile f
   -- Heap profiles do not support traces
   return (ph, fs, [])
 
-chunkT :: Text -> (PartialHeader, [Frame])
+chunkT :: Text -> (Header, [Frame])
 chunkT s =
   let ls = lines s
       (hs, ss) = splitAt 4 ls
@@ -22,7 +26,7 @@ chunkT s =
         zipWith header [sJOB, sDATE, sSAMPLE_UNIT, sVALUE_UNIT] hs
       fs = chunkSamples ss
   in  (
-        Header job date smpU valU
+        Header job date smpU valU (myLength fs)
       ,  fs
       )
 

--- a/src/HeapProf.hs
+++ b/src/HeapProf.hs
@@ -2,15 +2,12 @@
 module HeapProf (chunk) where
 
 import Prelude hiding (init, lookup, lines, words, drop, length, readFile)
+import qualified Prelude
 import Data.Text (Text, lines, init, drop, length, isPrefixOf, unpack, words, pack)
 import Data.Text.IO (readFile)
 import Data.Attoparsec.Text (parseOnly, double)
 
 import Types
-
-myLength :: [a] -> Int
-myLength [] = 0
-myLength (_:xs) = 1 + myLength xs
 
 chunk :: FilePath -> IO (Header, [Frame], [Trace])
 chunk f = do
@@ -26,7 +23,7 @@ chunkT s =
         zipWith header [sJOB, sDATE, sSAMPLE_UNIT, sVALUE_UNIT] hs
       fs = chunkSamples ss
   in  (
-        Header job date smpU valU (myLength fs)
+        Header job date smpU valU (Prelude.length fs)
       ,  fs
       )
 

--- a/src/Prune.hs
+++ b/src/Prune.hs
@@ -33,7 +33,7 @@ prune :: Compare (Text, (Double, Double)) -> Double -> Int -> Map Text (Double, 
 prune cmp tracePercent nBands ts =
   let ccTotals = sortBy cmpSizeDescending (toList ts)
       sizes = map (fst . snd) ccTotals
-      total = sum' sizes
+      total = sum sizes
       limit = if tracePercent == 0 then total
                                    else (1 - tracePercent / 100) * total
       bigs = takeWhile (< limit) . scanl (+) 0 $ sizes
@@ -41,5 +41,3 @@ prune cmp tracePercent nBands ts =
       ccs = map fst (sortBy cmp bands)
   in  fromList (reverse ccs `zip` [1 ..])
 
-sum' :: [Double] -> Double
-sum' = foldl' (+) 0

--- a/src/Prune.hs
+++ b/src/Prune.hs
@@ -1,9 +1,9 @@
 module Prune
   ( prune
   , Compare
-  , cmpName
-  , cmpSize
-  , cmpStdDev
+  , cmpNameAscending
+  , cmpSizeAscending
+  , cmpStdDevAscending
   ) where
 
 import Data.Text (Text)
@@ -13,25 +13,18 @@ import Data.Map.Strict (Map, toList, fromList)
 
 type Compare a = a -> a -> Ordering
 
-cmpName, cmpSize, cmpStdDev
-  :: (Compare (Text, (Double, Double)), Compare (Text, (Double, Double)))
-cmpName = (cmpNameAscending, cmpNameDescending)
-cmpSize = (cmpSizeDescending, cmpSizeAscending)
-cmpStdDev = (cmpStdDevDescending, cmpStdDevAscending)
-
-cmpNameAscending, cmpNameDescending,
-  cmpStdDevAscending, cmpStdDevDescending,
-  cmpSizeAscending, cmpSizeDescending :: Compare (Text, (Double, Double))
+cmpNameAscending :: Compare (Text, (Double, Double))
 cmpNameAscending = comparing fst
-cmpNameDescending = flip cmpNameAscending
+
+cmpStdDevAscending :: Compare (Text, (Double, Double))
 cmpStdDevAscending = comparing (snd . snd)
-cmpStdDevDescending = flip cmpStdDevAscending
+
+cmpSizeAscending :: Compare (Text, (Double, Double))
 cmpSizeAscending = comparing (fst . snd)
-cmpSizeDescending = flip cmpSizeAscending
 
 prune :: Compare (Text, (Double, Double)) -> Double -> Int -> Map Text (Double, Double) -> Map Text Int
 prune cmp tracePercent nBands ts =
-  let ccTotals = sortBy cmpSizeDescending (toList ts)
+  let ccTotals = sortBy (flip cmpSizeAscending) (toList ts)
       sizes = map (fst . snd) ccTotals
       total = sum sizes
       limit = if tracePercent == 0 then total

--- a/src/Total.hs
+++ b/src/Total.hs
@@ -20,13 +20,11 @@ data Parse =
 parse0 :: Parse
 parse0 = Parse{ symbols = empty, totals = empty, count = 0 }
 
-total :: PartialHeader -> [Frame] -> (Header, Map Text (Double, Double))
-total ph fs =
+total :: [Frame] -> Map Text (Double, Double)
+total fs =
   let parse1 = flip execState parse0 . mapM_ parseFrame $ fs
-  in  (
-       ph (count parse1)
-      , fmap (stddev $ fromIntegral (count parse1)) (totals parse1)
-      )
+  in fmap (stddev $ fromIntegral (count parse1)) (totals parse1)
+
 
 stddev :: Double -> (Double, Double) -> (Double, Double)
 stddev s0 (s1, s2) = (s1, sqrt (s0 * s2 - s1 * s1) / s0)

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -11,8 +11,6 @@ data Header =
   , hCount       :: Int
   }
 
-type PartialHeader = Int -> Header
-
 data Sample = Sample Text Double deriving Show
 
 data Frame = Frame Double [Sample] deriving Show


### PR DESCRIPTION
Simplifies computation in the backend by removing the intermediate partial header.

Also simplifies code for choosing the right comparison method based on commandline arguments.