### PR TITLE
Only update site when tags are pushed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,5 +34,5 @@ jobs:
         target_branch: gh-pages
         local_dir: site
         on:
-          branch: master
+          tags: true
 


### PR DESCRIPTION
This prevents confusing situations where the documentation is out of
sync with the version you can install on hackage.

Fixes #42