### PR TITLE
Remove partial header

### DIFF
--- a/src/Eventlog/Data.hs
+++ b/src/Eventlog/Data.hs
@@ -10,7 +10,6 @@ import Eventlog.Bands (bands)
 import qualified Eventlog.Events as E
 import qualified Eventlog.HeapProf as H
 import Eventlog.Prune (prune, cmpName, cmpSize, cmpStdDev)
-import Eventlog.Total (total)
 import Eventlog.Vega
 import Eventlog.Types (Header)
 
@@ -23,9 +22,7 @@ generateJson file a = do
         Size -> cmpSize
         StdDev -> cmpStdDev
       reversing' = if reversing a then swap else id
-  (ph, fs, traces) <- chunk file
-  let (counts, totals) = total fs
-  let h = ph counts
+  (h,totals, fs, traces) <- chunk file
   let keeps = prune cmp 0 (bound $ nBands a) totals
   let combinedJson = object [
           "samples" .= bandsToVega keeps (bands h keeps fs)

--- a/src/Eventlog/Data.hs
+++ b/src/Eventlog/Data.hs
@@ -24,7 +24,8 @@ generateJson file a = do
         StdDev -> cmpStdDev
       reversing' = if reversing a then swap else id
   (ph, fs, traces) <- chunk file
-  let (h, totals) = total ph fs
+  let (counts, totals) = total fs
+  let h = ph counts
   let keeps = prune cmp 0 (bound $ nBands a) totals
   let combinedJson = object [
           "samples" .= bandsToVega keeps (bands h keeps fs)

--- a/src/Eventlog/Events.hs
+++ b/src/Eventlog/Events.hs
@@ -11,8 +11,10 @@ import GHC.RTS.Events hiding (Header, header)
 import Prelude hiding (init, lookup)
 import qualified Data.Text as T
 import Data.Text (Text)
+import Data.Map (Map)
 
 import Eventlog.Types
+import Eventlog.Total
 import Data.List
 import Data.Function
 import Data.Word
@@ -25,8 +27,12 @@ import Data.Maybe
 fromNano :: Word64 -> Double
 fromNano e = fromIntegral e * 1e-9
 
-chunk :: FilePath -> IO (PartialHeader, [Frame], [Trace])
-chunk f = eventlogToHP . either error id =<< readEventLogFromFile f
+chunk :: FilePath -> IO (Header,Map Text (Double, Double), [Frame], [Trace])
+chunk f = do
+  el <- either error id <$> readEventLogFromFile f
+  (ph, frames, traces) <- eventlogToHP el
+  let (counts, totals) = total frames
+  return $ (ph counts, totals, frames, traces)
 
 eventlogToHP :: EventLog -> IO (PartialHeader, [Frame], [Trace])
 eventlogToHP (EventLog _h e) = do

--- a/src/Eventlog/Events.hs
+++ b/src/Eventlog/Events.hs
@@ -24,19 +24,17 @@ import qualified Data.Map as Map
 import Data.Vector.Unboxed (Vector, (!?))
 import Data.Maybe
 
+type PartialHeader = Int -> Header
+
 fromNano :: Word64 -> Double
 fromNano e = fromIntegral e * 1e-9
 
 chunk :: FilePath -> IO (Header,Map Text (Double, Double), [Frame], [Trace])
 chunk f = do
-  el <- either error id <$> readEventLogFromFile f
-  (ph, frames, traces) <- eventlogToHP el
+  (EventLog _ e) <- either error id <$> readEventLogFromFile f
+  (ph, frames, traces) <- eventsToHP e
   let (counts, totals) = total frames
   return $ (ph counts, totals, frames, traces)
-
-eventlogToHP :: EventLog -> IO (PartialHeader, [Frame], [Trace])
-eventlogToHP (EventLog _h e) = do
-  eventsToHP e
 
 eventsToHP :: Data -> IO (PartialHeader, [Frame], [Trace])
 eventsToHP (Data es) = do

--- a/src/Eventlog/HeapProf.hs
+++ b/src/Eventlog/HeapProf.hs
@@ -5,14 +5,17 @@ import Prelude hiding (init, lookup, lines, words, drop, length, readFile)
 import Data.Text (Text, lines, init, drop, length, isPrefixOf, unpack, words, pack)
 import Data.Text.IO (readFile)
 import Data.Attoparsec.Text (parseOnly, double)
+import Data.Map (Map)
 
+import Eventlog.Total
 import Eventlog.Types
 
-chunk :: FilePath -> IO (PartialHeader, [Frame], [Trace])
+chunk :: FilePath -> IO (Header, Map Text (Double, Double), [Frame], [Trace])
 chunk f = do
   (ph, fs) <- chunkT <$> readFile f
+  let (counts, totals) = total fs
   -- Heap profiles do not support traces
-  return (ph, fs, [])
+  return (ph counts, totals, fs, [])
 
 chunkT :: Text -> (PartialHeader, [Frame])
 chunkT s =

--- a/src/Eventlog/HeapProf.hs
+++ b/src/Eventlog/HeapProf.hs
@@ -17,7 +17,7 @@ chunk f = do
   -- Heap profiles do not support traces
   return (ph counts, totals, fs, [])
 
-chunkT :: Text -> (PartialHeader, [Frame])
+chunkT :: Text -> (Int -> Header, [Frame])
 chunkT s =
   let ls = lines s
       (hs, ss) = splitAt 4 ls

--- a/src/Eventlog/Total.hs
+++ b/src/Eventlog/Total.hs
@@ -19,11 +19,11 @@ data Parse =
 parse0 :: Parse
 parse0 = Parse{ symbols = empty, totals = empty, count = 0 }
 
-total :: PartialHeader -> [Frame] -> (Header, Map Text (Double, Double))
-total ph fs =
+total :: [Frame] -> (Int, Map Text (Double, Double))
+total fs =
   let parse1 = flip execState parse0 . mapM_ parseFrame $ fs
   in  (
-       ph (count parse1)
+       count parse1
       , fmap (stddev $ fromIntegral (count parse1)) (totals parse1)
       )
 

--- a/src/Eventlog/Types.hs
+++ b/src/Eventlog/Types.hs
@@ -11,8 +11,6 @@ data Header =
   , hCount       :: Int
   }
 
-type PartialHeader = Int -> Header
-
 data Sample = Sample Text Double deriving Show
 
 data Frame = Frame Double [Sample] deriving Show


### PR DESCRIPTION
The `total` function of the `Total.hs` module should not mention the Header. The call of the `total` function has been moved up from `Data.hs` to `Events.hs` and `HeapProf.hs` so that the `chunk` functions return the complete header and not the partially applied header.