### PR TITLE
Add warning when eventlog contains a lot of traces

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 unreleased
 
+* Added warning about eventlogs with a lot of traces.
 * Added option to filter the traces which should be included in the
   generated output.
 

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -6,6 +6,7 @@ import Control.Monad
 import Data.Aeson (encodeFile, Value, toJSON)
 import System.FilePath
 import System.Exit
+import System.IO
 
 import Eventlog.Args (args, Args(..))
 import Eventlog.Bands (bands)
@@ -13,6 +14,7 @@ import Eventlog.HtmlTemplate
 import Eventlog.Data
 import Eventlog.Vega
 import Eventlog.VegaTemplate
+import Eventlog.Types
 
 main :: IO ()
 main = do
@@ -37,7 +39,14 @@ doOneJson a fin fout = do
 
 doOneHtml :: Args -> FilePath -> FilePath -> IO ()
 doOneHtml a fin fout = do
-  (header, data_json) <- generateJson fin a
+  (header, data_json) <- generateJsonValidate checkTraces fin a
   let html = templateString header data_json a
   writeFile fout html
+  where
+    checkTraces :: ProfData -> IO ()
+    checkTraces (ProfData _ _ _ ts) =
+      if length ts > 1000
+        then hPutStrLn stderr
+              "More than 1000 traces, consider reducing using -i or -x"
+        else return ()
 

--- a/src/Eventlog/Data.hs
+++ b/src/Eventlog/Data.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
-module Eventlog.Data (generateJson) where
+module Eventlog.Data (generateJson, generateJsonValidate ) where
 
 import Prelude hiding (print, readFile)
 import Data.Aeson (Value(..), (.=), object)
@@ -10,16 +10,20 @@ import qualified Eventlog.Events as E
 import qualified Eventlog.HeapProf as H
 import Eventlog.Prune (prune)
 import Eventlog.Vega
-import Eventlog.Types (Header)
+import Eventlog.Types (Header, ProfData(..))
 
-generateJson :: FilePath -> Args -> IO (Header, Value)
-generateJson file a = do
+generateJsonValidate :: (ProfData -> IO ()) -> FilePath -> Args -> IO (Header, Value)
+generateJsonValidate validate file a = do
   let chunk = if heapProfile a then H.chunk else E.chunk a
-  (h,totals, fs, traces) <- chunk file
+  dat@(ProfData h totals fs traces) <- chunk file
+  validate dat
   let keeps = prune a 0 totals
-  let combinedJson = object [
+      combinedJson = object [
           "samples" .= bandsToVega keeps (bands h keeps fs)
         , "traces"  .= tracesToVega traces
         ]
   return (h, combinedJson)
+
+generateJson :: FilePath -> Args -> IO (Header, Value)
+generateJson = generateJsonValidate (const (return ()))
 

--- a/src/Eventlog/Events.hs
+++ b/src/Eventlog/Events.hs
@@ -11,7 +11,6 @@ import GHC.RTS.Events hiding (Header, header)
 import Prelude hiding (init, lookup)
 import qualified Data.Text as T
 import Data.Text (Text)
-import Data.Map (Map)
 
 import Eventlog.Types
 import Eventlog.Total
@@ -35,12 +34,12 @@ type PartialHeader = Int -> Header
 fromNano :: Word64 -> Double
 fromNano e = fromIntegral e * 1e-9
 
-chunk :: Args -> FilePath -> IO (Header,Map Text (Double, Double), [Frame], [Trace])
+chunk :: Args -> FilePath -> IO ProfData
 chunk a f = do
   (EventLog _ e) <- either error id <$> readEventLogFromFile f
   (ph, frames, traces) <- eventsToHP a e
   let (counts, totals) = total frames
-  return $ (ph counts, totals, frames, traces)
+  return $ (ProfData (ph counts) totals frames traces)
 
 checkGHCVersion :: EL -> Maybe String
 checkGHCVersion EL { ident = Just (version,_)}

--- a/src/Eventlog/HeapProf.hs
+++ b/src/Eventlog/HeapProf.hs
@@ -10,12 +10,12 @@ import Data.Map (Map)
 import Eventlog.Total
 import Eventlog.Types
 
-chunk :: FilePath -> IO (Header, Map Text (Double, Double), [Frame], [Trace])
+chunk :: FilePath -> IO ProfData
 chunk f = do
   (ph, fs) <- chunkT <$> readFile f
   let (counts, totals) = total fs
   -- Heap profiles do not support traces
-  return (ph counts, totals, fs, [])
+  return (ProfData (ph counts) totals fs [])
 
 chunkT :: Text -> (Int -> Header, [Frame])
 chunkT s =

--- a/src/Eventlog/Types.hs
+++ b/src/Eventlog/Types.hs
@@ -1,6 +1,7 @@
 module Eventlog.Types where
 
 import Data.Text (Text)
+import Data.Map (Map)
 
 data Header =
   Header
@@ -17,3 +18,5 @@ data Frame = Frame Double [Sample] deriving Show
 
 -- | A trace we also want to show on the graph
 data Trace = Trace Double Text deriving Show
+
+data ProfData = ProfData Header (Map Text (Double, Double)) [Frame] [Trace]


### PR DESCRIPTION
I chose the limit to be 1000 for now, that is probably still too many
but trying to display 500000 traces makes the graph take too long to
render.