### PR TITLE
Use the event from traceMarker rather than traceEvent

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -51,7 +51,7 @@ multi-threaded applications.
 ### Adding markers
 
 An advantage of using the eventlog is that other events can be correlated with
-heap allocations. Strings emitted using [`traceEvent`](http://hackage.haskell.org/package/base-4.12.0.0/docs/Debug-Trace.html#v:traceEvent) are displayed on the
+heap allocations. Strings emitted using [`traceMarker`](http://hackage.haskell.org/package/base-4.12.0.0/docs/Debug-Trace.html#v:traceMarker) are displayed on the
 chart as a verticle gray line. Hovering near the line will display the name of
 the event which is nearest to the cursor.
 

--- a/src/Eventlog/Events.hs
+++ b/src/Eventlog/Events.hs
@@ -111,8 +111,7 @@ folder a el (Event t e _) = el &
     case e of
       -- Traces
       RtsIdentifier _ ident -> addIdent ident
-      Message s -> addTrace a (Trace (fromNano t) (T.pack s))
-      UserMessage s -> addTrace a (Trace (fromNano t) (T.pack s))
+      UserMarker s -> addTrace a (Trace (fromNano t) (T.pack s))
       HeapProfBegin {} -> addFrame t
       HeapProfCostCentre cid l m loc _  -> addCostCentre cid (CC cid l m loc)
       HeapProfSampleBegin {} -> addFrame t


### PR DESCRIPTION
`traceEvent` is for high frequency events, whereas `traceMarker` is exactly for phase markers in the visual output of profile tools.

Fixes #94 

Note that this is an opinionated patch and it also drops the use of the `Message` event type as well as the `UserMessage`. Neither of these are intended for visual markers. It might still be interesting to get access to these events, like threadscope does, but there's a danger of data overload.