### PR TITLE
Enable -Werror for the library and the executable

### DIFF
--- a/eventlog2html.cabal
+++ b/eventlog2html.cabal
@@ -54,7 +54,7 @@ Library
     time                 >= 1.8.0 && < 2.0,
     vector               >= 0.11
 
-  GHC-options:         -Wall
+  GHC-options:         -Wall -Werror
   default-language:    Haskell2010
   HS-source-dirs:      src
   exposed-modules:     Eventlog.Args
@@ -71,6 +71,7 @@ Library
                        Eventlog.VegaTemplate
 
 Executable eventlog2html
+  GHC-options:         -Wall -Werror
   default-language:    Haskell2010
   HS-source-dirs:      main
   Main-is:             Main.hs

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -3,17 +3,14 @@
 module Main (main) where
 
 import Control.Monad
-import Data.Aeson (encodeFile, Value, toJSON)
+import Data.Aeson (encodeFile)
 import System.FilePath
 import System.Exit
 import System.IO
 
 import Eventlog.Args (args, Args(..))
-import Eventlog.Bands (bands)
 import Eventlog.HtmlTemplate
 import Eventlog.Data
-import Eventlog.Vega
-import Eventlog.VegaTemplate
 import Eventlog.Types
 
 main :: IO ()
@@ -23,9 +20,9 @@ main = do
   argsToOutput a
 
 argsToOutput :: Args -> IO ()
-argsToOutput a@Args{files = files, outputFile = Nothing} =
-  if | json a    -> forM_ files $ \file -> doOneJson a file (file <.> "json")
-     | otherwise -> forM_ files $ \file -> doOneHtml a file (file <.> "html")
+argsToOutput a@Args{files = files', outputFile = Nothing} =
+  if | json a    -> forM_ files' $ \file -> doOneJson a file (file <.> "json")
+     | otherwise -> forM_ files' $ \file -> doOneHtml a file (file <.> "html")
 argsToOutput a@Args{files = [fin], outputFile = Just fout} =
   if | json a    -> doOneJson a fin fout
      | otherwise -> doOneHtml a fin fout


### PR DESCRIPTION
* Enables -Werror for the library and -Wall and -Werror for the executable.
* Fixes the warnings generated by enabling -Wall for the executable.