### PR TITLE
Removed code which had no observable effect on program

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 unreleased
 
+* Removed "trace PERCENT" option, which had no effect in the code.
 * Added warning about eventlogs with a lot of traces.
 * Added option to filter the traces which should be included in the
   generated output.

--- a/src/Eventlog/Args.hs
+++ b/src/Eventlog/Args.hs
@@ -18,7 +18,6 @@ data Args = Args
   {
     sorting      :: Sort
   , reversing    :: Bool
-  , tracePercent :: Double
   , nBands       :: Int
   , heapProfile  :: Bool
   , noIncludejs    :: Bool
@@ -41,12 +40,6 @@ argParser = Args
       <*> switch
           ( long "reverse"
          <> help "Reverse the order of bands." )
-      <*> option auto
-          ( long "trace"
-         <> help "Percentage of trace elements to combine."
-         <> value 1
-         <> showDefault
-         <> metavar "PERCENT" )
       <*> option auto
           ( long "bands"
          <> help "Maximum number of bands to draw (0 for unlimited)."

--- a/src/Eventlog/Data.hs
+++ b/src/Eventlog/Data.hs
@@ -17,7 +17,7 @@ generateJsonValidate validate file a = do
   let chunk = if heapProfile a then H.chunk else E.chunk a
   dat@(ProfData h totals fs traces) <- chunk file
   validate dat
-  let keeps = prune a 0 totals
+  let keeps = prune a totals
       combinedJson = object [
           "samples" .= bandsToVega keeps (bands h keeps fs)
         , "traces"  .= tracesToVega traces

--- a/src/Eventlog/Prune.hs
+++ b/src/Eventlog/Prune.hs
@@ -3,7 +3,7 @@ module Eventlog.Prune
   ) where
 
 import Data.Text (Text)
-import Data.List (foldl', sortBy)
+import Data.List (sortBy)
 import Data.Ord (comparing)
 import Data.Map.Strict (Map, toList, fromList)
 
@@ -29,13 +29,11 @@ cmpStdDevDescending = flip cmpStdDevAscending
 cmpSizeAscending = comparing (fst . snd)
 cmpSizeDescending = flip cmpSizeAscending
 
-prune :: Args -> Double -> Map Text (Double, Double) -> Map Text Int
-prune args percent ts =
+prune :: Args -> Map Text (Double, Double) -> Map Text Int
+prune args ts =
   let ccTotals = sortBy cmpSizeDescending (toList ts)
       sizes = map (fst . snd) ccTotals
-      total = sum' sizes
-      limit = if percent == 0 then total
-                                   else (1 - percent / 100) * total
+      limit = sum sizes
       bigs = takeWhile (< limit) . scanl (+) 0 $ sizes
       bands = zipWith const ccTotals $ take (bound $ nBands args) bigs
       ccs = map fst (sortBy (getComparison args) bands)
@@ -46,5 +44,3 @@ bound n
   | n <= 0 = maxBound
   | otherwise = n
 
-sum' :: [Double] -> Double
-sum' = foldl' (+) 0

--- a/src/Eventlog/Total.hs
+++ b/src/Eventlog/Total.hs
@@ -2,7 +2,7 @@
 module Eventlog.Total (total) where
 
 import Control.Monad.State.Strict (State(), execState, get, put, modify)
-import Data.Map (Map, empty, lookup, insert, alter)
+import Data.Map (Map, empty, alter)
 import Prelude hiding (init, lookup, lines, words, drop, length, readFile)
 import Data.Text (Text)
 
@@ -11,13 +11,12 @@ import Eventlog.Types
 
 data Parse =
   Parse
-  { symbols   :: !(Map Text Text) -- intern symbols to save RAM
-  , totals    :: !(Map Text (Double, Double)) -- compute running totass and total of squares
+  { totals    :: !(Map Text (Double, Double)) -- compute running totass and total of squares
   , count     :: !Int                         -- number of frames
   }
 
 parse0 :: Parse
-parse0 = Parse{ symbols = empty, totals = empty, count = 0 }
+parse0 = Parse{ totals = empty, count = 0 }
 
 total :: [Frame] -> (Int, Map Text (Double, Double))
 total fs =
@@ -39,13 +38,7 @@ parseFrame (Frame _time ls) = do
 inserter :: Sample -> State Parse Double
 inserter (Sample k v) = do
   p <- get
-  k' <- case lookup k (symbols p) of
-    Nothing -> do
-      put $! p{ symbols = insert k k (symbols p) }
-      return k
-    Just kk -> return kk
-  p' <- get
-  put $! p'{ totals = alter (accum  v) k' (totals p') }
+  put $! p { totals = alter (accum  v) k (totals p) }
   return $! v
 
 accum :: Double -> Maybe (Double, Double) -> Maybe (Double, Double)


### PR DESCRIPTION
* tracePercent was never used. Alternative: Was it supposed to be used in prune as the percent argument? In that case, tracePercent can be called in prune.
* the `symbols` map in `Total.hs` is very strange. Only identical pairs "k k" had been inserted, it worked more like a set than a map. But the symbols weren't used anyway. The removal should save two (log n) operations per sample in the inserter.