### PR TITLE
Add --y-axis option to specify precise extent of y-axis

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+0.6,
+
+* Add `--y-axis` option to allow the user to specify the extent of the y-axis.
+  This is useful when comparing two different profiles together.
+
 0.5, released 2019-10-11
 
 * Add some more metainformation to the header (sample mode and sample interval)

--- a/hakyll-eventlog/site.hs
+++ b/hakyll-eventlog/site.hs
@@ -116,10 +116,10 @@ drawEventlog args vid conf  = do
   return $ renderHtml $ renderChartWithJson vid dat (vegaJsonText conf)
 
 def :: ChartConfig
-def = ChartConfig 600 500 True "category20" (AreaChart Stacked)
+def = ChartConfig 600 500 True "category20" (AreaChart Stacked) Nothing
 
 exampleConf :: ChartConfig
-exampleConf = ChartConfig 500 300 False "category20" (AreaChart Stacked)
+exampleConf = ChartConfig 500 300 False "category20" (AreaChart Stacked) Nothing
 
 chartConfig :: [(String, String)] -> ChartConfig
 chartConfig as = foldr go def as

--- a/src/Eventlog/Args.hs
+++ b/src/Eventlog/Args.hs
@@ -26,6 +26,7 @@ data Args = Args
   , traceEvents  :: Bool -- ^ By default, only traceMarkers are included.
                          -- This option enables the inclusion of traceEvents.
   , userColourScheme :: Text
+  , fixedYAxis :: Maybe Int
   , includeStr :: [Text]
   , excludeStr :: [Text]
   , outputFile :: Maybe String
@@ -72,6 +73,10 @@ argParser = Args
           ( long "colour-scheme"
           <> value "category20b"
           <> help "The name of the colour scheme. See the vega documentation (https://vega.github.io/vega/docs/schemes/#reference) for a complete list. Examples include \"category10\" \"dark2\" \"tableau10\". ")
+      <*> option (Just <$> auto)
+          ( long "y-axis"
+          <> value Nothing
+          <> help "Fixed value for the maximum extent of the y-axis in bytes. This option is useful for comparing profiles together.")
       <*> many (option str
           (short 'i'
           <> long "include"

--- a/src/Eventlog/HtmlTemplate.hs
+++ b/src/Eventlog/HtmlTemplate.hs
@@ -113,7 +113,7 @@ template header' dat as = docTypeHtml $ do
     script $ preEscapedToHtml tablogic
 
 htmlConf :: Args -> ChartType -> ChartConfig
-htmlConf as = ChartConfig 1200 1000 (not (noTraces as)) (userColourScheme as)
+htmlConf as ct = ChartConfig 1200 1000 (not (noTraces as)) (userColourScheme as) ct (fromIntegral <$> (fixedYAxis as))
 
 renderChart :: VizID -> Text -> Html
 renderChart vid vegaSpec = do

--- a/src/Eventlog/VegaTemplate.hs
+++ b/src/Eventlog/VegaTemplate.hs
@@ -38,6 +38,7 @@ data ChartConfig =
               , traces :: Bool
               , colourScheme :: Text
               , chartType :: ChartType
+              , fixedYAxisExtent :: Maybe Double
               }
 
 colourProperty :: ChartConfig -> ScaleProperty
@@ -190,7 +191,7 @@ encodingBandsLayer ct c =
         ]
     . position X [PName "x", PmType Quantitative, PAxis [AxTitle ""]
                  , PScale [SDomain (DSelection "brush")]]
-    . position Y [PName "y"
+    . position Y ([PName "y"
                  , PmType Quantitative
                  , PAxis $ case ct of
                              Stacked -> [AxTitle "Allocation"
@@ -204,6 +205,8 @@ encodingBandsLayer ct c =
                              Stacked -> StZero
                              Normalized -> StNormalize
                              StreamGraph -> StCenter)]
+                 ++
+                  [PScale [SDomain (DNumbers [0,  extent])] | Just extent <- [fixedYAxisExtent c]] )
 
 transformBandsLayer :: [LabelledSpec] -> (VLProperty, VLSpec)
 transformBandsLayer =


### PR DESCRIPTION
This is useful when comparing two profiles together. It would be
possible to also implement:

* The old `--uniform-scales` options from hp2pretty which had the effect
of automatically choosing the maximum extent based on the maximum value
amongst all profiles.
* A smarter parser for specifying the extent such as (80M for 80mb)

cc @AndreasPK