### PR TITLE
Display sample points on the line chart

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+* Line chart now displays points for each sample so it's easier to see where to hover.
+
 0.5, released 2019-10-11
 
 * Add some more metainformation to the header (sample mode and sample interval)

--- a/src/Eventlog/VegaTemplate.hs
+++ b/src/Eventlog/VegaTemplate.hs
@@ -104,7 +104,7 @@ linesLayer c = asSpec
     VL.width (0.9 * cwidth c),
     VL.height (0.7 * cheight c),
     dataFromSource "data_json_samples" [],
-    VL.mark Line [],
+    VL.mark Line [MPoint (PMMarker [])],
     encodingLineLayer c [],
     transformLineLayer []
   ]


### PR DESCRIPTION
This makes it much easier to see where to hover to see which line is
which. I tried it on a profile with quite a lot of samples and it didn't
look completely awful, so I think we should turn it on for now.

Fixes #107 