### PR TITLE
Fix start frame time

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,4 @@
+* Fix incorrectly calculated start time for certain profiles.
 * Line chart now displays points for each sample so it's easier to see where to hover.
 
 0.5, released 2019-10-11

--- a/src/Eventlog/Events.hs
+++ b/src/Eventlog/Events.hs
@@ -110,8 +110,8 @@ data CostCentre = CC { cid :: Word32
                      , modul :: Text
                      , loc :: Text } deriving Show
 
-initEL :: Word64 -> EL
-initEL t = EL
+initEL :: EL
+initEL = EL
   { pargs = Nothing
   , ident = Nothing
   , samplingRate = Nothing
@@ -120,17 +120,16 @@ initEL t = EL
   , samples = Nothing
   , frames = []
   , traces = []
-  , start = t
+  , start = 0
   , end = 0
   , ccMap = Map.empty
   , ccsMap =  CCSMap Trie.empty 0
   }
 
 foldEvents :: Args -> [Event] -> EL
-foldEvents a (e:es) =
-  let res = foldl' (folder a)  (initEL (evTime e)) (e:es)
+foldEvents a es =
+  let res = foldl' (folder a) initEL es
   in addFrame 0 res
-foldEvents _ [] = error "Empty event log"
 
 folder :: Args -> EL -> Event -> EL
 folder a el (Event t e _) = el &


### PR DESCRIPTION
For some reason the events in the eventlog are not ordered in all
situations. Therefore taking the time of the first event doesn't give
you the actual start time. I don't see any reason why the start time
should be anything other than 0 so I just hard coded it in now.

Thanks to Andres for pointing out another bug.