### PR TITLE
show cost centres in detailed view

### DIFF
--- a/src/Eventlog/Data.hs
+++ b/src/Eventlog/Data.hs
@@ -1,4 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 module Eventlog.Data (generateJson, generateJsonValidate, generateJsonData ) where
 
 import Prelude hiding (readFile)
@@ -42,7 +45,7 @@ generateJsonData a (ProfData h binfo ccMap fs traces heap_info ipes) = do
       closure_table =
         case detailedLimit a of
           Just 0 ->  Nothing
-          _ -> Just (renderClosureInfo bs' use_ipes desc_buckets)
+          _ -> Just (renderClosureInfo bs' use_ipes desc_buckets (Just ccMap))
   return (h, combinedJson, cc_descs, closure_table)
 
 generateJson :: FilePath -> Args -> IO (Header, Value, Maybe Value, Maybe Html)
@@ -55,4 +58,3 @@ generateJsonValidate validate file a = do
   dat <- chunk file
   validate dat
   generateJsonData a dat
-

--- a/src/Eventlog/Events.hs
+++ b/src/Eventlog/Events.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE StrictData #-}
 {-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE TypeApplications #-}
-module Eventlog.Events(chunk) where
+module Eventlog.Events(CostCentreMap, chunk) where
 
 import GHC.RTS.Events hiding (Header, header, liveBytes, blocksSize)
 import Prelude hiding (init, lookup)
@@ -85,6 +85,7 @@ normalise :: [FrameEL] -> [Frame]
 normalise = map (\(FrameEL t ss) -> Frame (fromNano t) ss)
 
 type BucketMap = Map.Map Bucket (Text, Maybe [Word32])
+type CostCentreMap = Map.Map Word32 CostCentre
 
 data EL = EL
   { pargs :: !(Maybe [Text])
@@ -95,7 +96,7 @@ data EL = EL
   , ident :: Maybe (Version, Text)
   , samplingRate :: !(Maybe Word64)
   , heapProfileType :: !(Maybe HeapProfBreakdown)
-  , ccMap :: !(Map.Map Word32 CostCentre)
+  , ccMap :: !CostCentreMap
   -- At the moment bucketMap and CCS map are quite similar, cost centre profiling
   -- is the only mode to populate the bucket map
   , bucketMap :: BucketMap


### PR DESCRIPTION
Fixes #145  and hopefully doesn't break any thing else, assuming the CcMap is empty for non `-hc` dumps