### PR TITLE
Hide "Detailed" table until fully loaded

### DIFF
--- a/src/Eventlog/Detailed.hs
+++ b/src/Eventlog/Detailed.hs
@@ -42,7 +42,7 @@ renderClosureInfo (ts, bs) mipes raw_bs = do
              Just ipes -> mkClosureInfo raw_bs ipes
              Nothing   -> Map.map (\v -> (None, v)) raw_bs
 
-  H.table ! A.id "closure_table" ! A.class_ "table table-striped closureTable" $ do
+  H.table ! A.id "closure_table" ! A.class_ "table table-striped closureTable" ! A.hidden "true" $ do
     H.thead $ H.tr $ do
       H.th "Profile"
       numTh "n"
@@ -126,7 +126,8 @@ initTable = "$(document).ready(function() {\
         \});\
         \$.fn.sparkline.defaults.common.chartRangeMin = 0;\
         \$.fn.sparkline.defaults.common.width = 200;\
-        \$('.linechart').sparkline()\
+        \$('.linechart').sparkline();\
+        \$(\".closureTable\").removeAttr(\"hidden\")\
 \});"
 
 getBandValues :: Int


### PR DESCRIPTION
This patch hides the table in the "Detailed" tab until it is all loaded and the pagination is initialised.
This avoids performance issues from browsers rendering the entire table while it loads in. This can make a large difference for large eventlogs

For a 27M report, this reduces loading time from 54s to 14s. Before the change the majority of the time is spent rendering, while afterwards it's only 19ms