### PR TITLE
Simplify units in detailed view

### DIFF
--- a/eventlog2html.cabal
+++ b/eventlog2html.cabal
@@ -48,6 +48,7 @@ Library
     hvega                >= 0.11.0 && < 0.12,
     mtl                  >= 2.2.2 && < 2.3,
     optparse-applicative >= 0.14.3 && < 0.17,
+    regex-applicative    >= 0.3.4 && <0.4,
     semigroups           >= 0.18 && < 0.20,
     text                 >= 1.2.3 && < 1.3,
     time                 >= 1.8.0 && < 2.0,


### PR DESCRIPTION
This is RFC.

Probably such functionality should be controlled by an argument flag, and applied to the graphs too. If that is fine, I'll amend this PR

---

Before

![Screenshot from 2021-08-25 16-42-33](https://user-images.githubusercontent.com/51087/130804765-491e5e31-d7ce-45a0-8930-0bcf7a552b09.png)

After

![Screenshot from 2021-08-25 16-58-13](https://user-images.githubusercontent.com/51087/130804799-74ce69c3-43e4-4c6e-a0d2-9578c7a1b985.png)

---

Note: in HTML display we can have a tooltip with original name. I didn't do it yet.