### PR TITLE
Add -v / --version option to command line

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+Unreleased
+
+* Add "--version" flag for eventlog2html which prints the version,
+  git commit and git branch used to build eventlog2html.
+
 0.9.2 release 2021-11-24
 
 * Improve profile load speed (#150)

--- a/eventlog2html.cabal
+++ b/eventlog2html.cabal
@@ -87,8 +87,11 @@ Executable eventlog2html
       base >= 4 && < 5,
       eventlog2html,
       aeson                >= 1.4.3 && < 1.6,
+      githash              >= 0.1.6.2 && < 0.1.7,
       text                 >= 1.2.3 && < 1.3,
       filepath             >= 1.4.2 && < 1.5
+  other-modules:       Paths_eventlog2html
+  autogen-modules:     Paths_eventlog2html
 
 
 Source-repository head

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -1,27 +1,43 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE MultiWayIf #-}
+{-# LANGUAGE TemplateHaskell #-}
 module Main (main) where
 
 import Control.Monad
 import Data.Aeson (encodeFile)
+import Data.Version (showVersion)
 import GHC.IO.Encoding (setLocaleEncoding)
+import GitHash (tGitInfoCwd, giHash, giBranch)
 import System.FilePath
 import System.Exit
 import System.IO
 
-import Eventlog.Args (args, Args(..))
+import Eventlog.Args (args, Args(..), Option(..))
 import Eventlog.HtmlTemplate
 import Eventlog.Data
 import Eventlog.Types
+import Paths_eventlog2html (version)
 
 main :: IO ()
 main = do
   -- This fixes a problem for Windows users: https://serokell.io/blog/haskell-with-utf8
   setLocaleEncoding utf8
   a <- args
+  dispatch a
+
+
+dispatch :: Option -> IO ()
+dispatch ShowVersion = printVersion
+dispatch (Run a) = do
   when (null (files a)) exitSuccess
   argsToOutput a
 
+printVersion :: IO ()
+printVersion = do
+    let gi = $$tGitInfoCwd
+    putStrLn $ "eventlog2html Version: " <> showVersion version
+    putStrLn $ "Git Commit:            " <> giHash gi
+    putStrLn $ "Git Branch:            " <> giBranch gi
 
 argsToOutput :: Args -> IO ()
 argsToOutput a@Args{files = files', outputFile = Nothing} =

--- a/src/Eventlog/Args.hs
+++ b/src/Eventlog/Args.hs
@@ -128,6 +128,7 @@ args = execParser argsInfo
 versionParser :: Parser Option
 versionParser = flag' ShowVersion
   (  long "version"
+  <> short 'v'
   <> help "Show the version of eventlog2html" )
 
 defaultArgs :: FilePath -> IO Option
@@ -137,7 +138,7 @@ defaultArgs fp = handleParseResult (execParserPure defaultPrefs argsInfo [fp])
 argsInfo :: ParserInfo Option
 argsInfo = opts
   where
-    opts = info ((versionParser <|> argParser) <**> helper)
+    opts = info ((argParser <|> versionParser) <**> helper)
       ( fullDesc
      <> progDesc "Convert eventlogs FILES.eventlog to interactive FILES.html"
      <> header "eventlog2html - generate interactive html from eventlogs" )


### PR DESCRIPTION
Hacking at Munihac I noticed that we embed the version of eventlog2html in the html, but there is no command line option to query eventlog2html for its version.

The `--version` option also includes the git commit and git branch from which it was built. This presupposes that a `.git` folder is available at build time. If it isn't (e.g. we are building from hackage), then this information is omitted.

## Example output with git information

```console
> cabal run eventlog2html -- --version
eventlog2html Version: 0.9.2
Git Commit:            ce528531cb9342d75a471eeb00d38e34fe43bf0e
Git Branch:            add-version-parser
```

## Example output without git information

```console
> cabal run eventlog2html -- --version
eventlog2html Version: 0.9.2
```

