### PR TITLE
Change version bounds of mtl for compatibility with GHC 9.6.*

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Unreleased:
+
+* Compatibility with GHC 9.2.* 9.4.* and 9.6.*
+
 0.10.0 release 2023-03-31
 
 * Add support for rendering ticky profiles
@@ -6,7 +10,7 @@
 
 * Add "--version" flag for eventlog2html which prints the version,
   git commit and git branch used to build eventlog2html.
-* Compatability with 9.4.* and 9.2.* compilers.
+* Compatibility with 9.4.* and 9.2.* compilers.
 
 0.9.2 release 2021-11-24
 

--- a/eventlog2html.cabal
+++ b/eventlog2html.cabal
@@ -30,7 +30,7 @@ Extra-source-files:
   javascript/generated/vega-lite@4.17.0
 extra-doc-files: README.md
                  CHANGELOG
-Tested-With:         GHC ==9.2.5, GHC ==9.4.3
+Tested-With:         GHC ==9.2.5, GHC ==9.4.5, GHC ==9.6.1
 
 Library
   Build-depends:
@@ -47,7 +47,7 @@ Library
     ghc-events           >= 0.19.0 && < 0.20,
     hashtables           >= 1.2.3 && < 1.4,
     hvega                >= 0.11.0 && < 0.13,
-    mtl                  >= 2.2.2 && < 2.3,
+    mtl                  >= 2.3.0 && < 2.4,
     optparse-applicative >= 0.14.3 && < 0.18,
     semigroups           >= 0.18 && < 0.21,
     text                 >= 1.2.3 && < 1.3 || >= 2.0 && < 2.1,


### PR DESCRIPTION
Fixes #168 

Tested locally with `cabal build` and GHC 9.2.5, 9.4.5 and 9.6.1.

