### PR TITLE
Add GHC-9.10 to the build matrix

### DIFF
--- a/.github/workflows/ghc-matrix.yml
+++ b/.github/workflows/ghc-matrix.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        ghc-version: ['9.0.2', '9.2.7', '9.4.7', '9.6.2', '9.8.1']
+        ghc-version: ['9.0.2', '9.2.7', '9.4.7', '9.6.2', '9.8.1', '9.10.1']
 
         include:
           - os: windows-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Unreleased
 ----------
 
 * Fix build error due to new exported function in blaze-html [#186](https://github.com/mpickering/eventlog2html/issues/186)
+* Add `GHC 9.10.1` to the build matrix.
 
 0.11.0 release 2024-02-06
 -------------------------

--- a/eventlog2html.cabal
+++ b/eventlog2html.cabal
@@ -32,7 +32,7 @@ Extra-source-files:
   inline-docs/*.html
 extra-doc-files: README.md
                  CHANGELOG.md
-Tested-With:         GHC ==9.0.2, GHC ==9.2.7, GHC ==9.4.7, GHC ==9.6.2, GHC ==9.8.1
+Tested-With:         GHC ==9.0.2, GHC ==9.2.7, GHC ==9.4.7, GHC ==9.6.2, GHC ==9.8.1, GHC==9.10.1
 
 Library
   Build-depends:


### PR DESCRIPTION
~~Currently blocked on 9.10 support of ghc-events: https://github.com/haskell/ghc-events/pull/105~~ Edit: Fixed now.